### PR TITLE
Force Gleam compatibility > 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Given a typical `lustre/ssg` `build.gleam` file with the following `main()` func
 
 ```gleam
 import glimra
+import glimra/theme
 
 pub fn main() {
   let syntax_highlighter =

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,6 @@
 name = "glimra"
 version = "2.0.0"
+gleam = ">= 1.40.0"
 target = "erlang"
 description = "Zero runtime syntax highlighter for lustre/ssg."
 licences = ["MIT"]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "glimra"
 version = "2.0.0"
-gleam = ">= 1.40.0"
+gleam = ">= 1.4.0"
 target = "erlang"
 description = "Zero runtime syntax highlighter for lustre/ssg."
 licences = ["MIT"]


### PR DESCRIPTION
Great project!

Just opened this tiny PR because I was unable to use this package until I realized I was on gleam 1.3.2 and you are using the new labels syntax introduced in 1.4.0. Also with the README snippet there's a reference to theme used, so thought it may be helpful to include it. 

Thanks for this! I have high hopes for this package!